### PR TITLE
Add AWS credentials handling to Terraform API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,16 @@ next-env.d.ts
 # git attributes
 .gitattributes
 
-ignore
+# terraform
+terraform-workspaces/
+*.tfstate
+*.tfstate.*
+.terraform/
+terraform.tfplan
+terraform.tfplan.*
+*.tfplan
+*.tfplan.*
+
+# local terraform files
+.terraform.lock.hcl
+*.tfvars

--- a/app/api/terraform/destroy/route.ts
+++ b/app/api/terraform/destroy/route.ts
@@ -1,10 +1,11 @@
 import { spawn } from 'child_process'
 import { NextRequest, NextResponse } from 'next/server'
+import { CredentialManager } from '@/lib/credential-manager'
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { workingDirectory, autoApprove } = body
+    const { workingDirectory, autoApprove, credentials } = body
 
     if (!workingDirectory) {
       return NextResponse.json(
@@ -13,8 +14,28 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Set AWS credentials as environment variables if provided
+    const env = { ...process.env }
+    if (credentials?.aws) {
+      // Validate AWS credentials format
+      const validationErrors = CredentialManager.validateAWSCredentials(credentials.aws)
+      if (validationErrors.length > 0) {
+        return NextResponse.json(
+          { error: `Invalid AWS credentials: ${validationErrors.join(', ')}` },
+          { status: 400 }
+        )
+      }
+
+      env.AWS_ACCESS_KEY_ID = credentials.aws.accessKeyId
+      env.AWS_SECRET_ACCESS_KEY = credentials.aws.secretAccessKey
+      env.AWS_DEFAULT_REGION = credentials.aws.region
+      console.log('🔑 Using AWS credentials for terraform destroy')
+    } else {
+      console.warn('⚠️ No AWS credentials provided for terraform destroy')
+    }
+
     const args = autoApprove ? ['-auto-approve'] : []
-    const result = await executeTerraformCommand('destroy', args, workingDirectory)
+    const result = await executeTerraformCommand('destroy', args, workingDirectory, env)
     
     return NextResponse.json(result)
   } catch (error) {
@@ -29,12 +50,14 @@ export async function POST(request: NextRequest) {
 function executeTerraformCommand(
   command: string,
   args: string[],
-  workingDirectory: string
+  workingDirectory: string,
+  env?: NodeJS.ProcessEnv
 ): Promise<{ success: boolean; output: string; error?: string; exitCode: number }> {
   return new Promise((resolve) => {
     const terraform = spawn('terraform', [command, ...args], {
       cwd: workingDirectory,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: env || process.env
     })
 
     let output = ''

--- a/app/api/terraform/output/route.ts
+++ b/app/api/terraform/output/route.ts
@@ -1,10 +1,11 @@
 import { spawn } from 'child_process'
 import { NextRequest, NextResponse } from 'next/server'
+import { CredentialManager } from '@/lib/credential-manager'
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { workingDirectory } = body
+    const { workingDirectory, credentials } = body
 
     if (!workingDirectory) {
       return NextResponse.json(
@@ -13,7 +14,27 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const result = await executeTerraformCommand('output', ['-json'], workingDirectory)
+    // Set AWS credentials as environment variables if provided
+    const env = { ...process.env }
+    if (credentials?.aws) {
+      // Validate AWS credentials format
+      const validationErrors = CredentialManager.validateAWSCredentials(credentials.aws)
+      if (validationErrors.length > 0) {
+        return NextResponse.json(
+          { error: `Invalid AWS credentials: ${validationErrors.join(', ')}` },
+          { status: 400 }
+        )
+      }
+
+      env.AWS_ACCESS_KEY_ID = credentials.aws.accessKeyId
+      env.AWS_SECRET_ACCESS_KEY = credentials.aws.secretAccessKey
+      env.AWS_DEFAULT_REGION = credentials.aws.region
+      console.log('🔑 Using AWS credentials for terraform output')
+    } else {
+      console.warn('⚠️ No AWS credentials provided for terraform output')
+    }
+
+    const result = await executeTerraformCommand('output', ['-json'], workingDirectory, env)
     
     return NextResponse.json(result)
   } catch (error) {
@@ -28,12 +49,14 @@ export async function POST(request: NextRequest) {
 function executeTerraformCommand(
   command: string,
   args: string[],
-  workingDirectory: string
+  workingDirectory: string,
+  env?: NodeJS.ProcessEnv
 ): Promise<{ success: boolean; output: string; error?: string; exitCode: number }> {
   return new Promise((resolve) => {
     const terraform = spawn('terraform', [command, ...args], {
       cwd: workingDirectory,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: env || process.env
     })
 
     let output = ''

--- a/app/api/terraform/validate/route.ts
+++ b/app/api/terraform/validate/route.ts
@@ -1,10 +1,11 @@
 import { spawn } from 'child_process'
 import { NextRequest, NextResponse } from 'next/server'
+import { CredentialManager } from '@/lib/credential-manager'
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { workingDirectory } = body
+    const { workingDirectory, credentials } = body
 
     if (!workingDirectory) {
       return NextResponse.json(
@@ -13,7 +14,27 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const result = await executeTerraformCommand('validate', [], workingDirectory)
+    // Set AWS credentials as environment variables if provided
+    const env = { ...process.env }
+    if (credentials?.aws) {
+      // Validate AWS credentials format
+      const validationErrors = CredentialManager.validateAWSCredentials(credentials.aws)
+      if (validationErrors.length > 0) {
+        return NextResponse.json(
+          { error: `Invalid AWS credentials: ${validationErrors.join(', ')}` },
+          { status: 400 }
+        )
+      }
+
+      env.AWS_ACCESS_KEY_ID = credentials.aws.accessKeyId
+      env.AWS_SECRET_ACCESS_KEY = credentials.aws.secretAccessKey
+      env.AWS_DEFAULT_REGION = credentials.aws.region
+      console.log('🔑 Using AWS credentials for terraform validate')
+    } else {
+      console.warn('⚠️ No AWS credentials provided for terraform validate')
+    }
+
+    const result = await executeTerraformCommand('validate', [], workingDirectory, env)
     
     return NextResponse.json(result)
   } catch (error) {
@@ -28,12 +49,14 @@ export async function POST(request: NextRequest) {
 function executeTerraformCommand(
   command: string,
   args: string[],
-  workingDirectory: string
+  workingDirectory: string,
+  env?: NodeJS.ProcessEnv
 ): Promise<{ success: boolean; output: string; error?: string; exitCode: number }> {
   return new Promise((resolve) => {
     const terraform = spawn('terraform', [command, ...args], {
       cwd: workingDirectory,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: env || process.env
     })
 
     let output = ''

--- a/components/terraform-generator.ts
+++ b/components/terraform-generator.ts
@@ -1,5 +1,3 @@
-import { ConfigLoader, type ServiceConfig } from "@/lib/config-loader"
-import { NetworkInfrastructureGenerator } from "@/lib/network-infrastructure-generator"
 import type { Edge, Node } from "@xyflow/react"
 
 export interface TerraformResource {
@@ -27,8 +25,8 @@ export class TerraformGenerator {
     this.edges = edges
   }
 
-  async generate(): Promise<TerraformOutput> {
-    const resources = await this.generateResources()
+  generate(): TerraformOutput {
+    const resources = this.generateResources()
     const variables = this.generateVariables()
     const outputs = this.generateOutputs()
 
@@ -40,22 +38,12 @@ export class TerraformGenerator {
     }
   }
 
-  private async generateResources(): Promise<TerraformResource[]> {
+  private generateResources(): TerraformResource[] {
     const resources: TerraformResource[] = []
     
-    // Generate VPC infrastructure if needed (AWS only)
-    if (this.provider === 'aws' && NetworkInfrastructureGenerator.needsVPCInfrastructure(this.nodes)) {
-      // Add VPC infrastructure resources
-      resources.push(...NetworkInfrastructureGenerator.generateVPCInfrastructure())
-      
-      // Add default security group and its rules
-      resources.push(NetworkInfrastructureGenerator.generateDefaultSecurityGroup())
-      resources.push(...NetworkInfrastructureGenerator.generateSecurityGroupRules())
-    }
-    
-    for (const node of this.nodes) {
+    this.nodes.forEach((node) => {
       const dependencies = this.getDependencies(node.id)
-      const config = await this.generateResourceConfig(node)
+      const config = this.generateResourceConfig(node)
 
       // Add the main resource
       resources.push({
@@ -81,36 +69,100 @@ export class TerraformGenerator {
           dependencies: [`${node.data.terraformType as string}.${this.sanitizeName((node.data.name as string) || (node.data.id as string))}`],
         })
       }
+
+      if (node.data.id === 'lambda') {
+        // Add IAM role for Lambda function
+        const resourceName = this.sanitizeName((node.data.name as string) || (node.data.id as string))
+        resources.push({
+          type: 'aws_iam_role',
+          name: `${resourceName}_role`,
+          config: {
+            name: `${resourceName}-execution-role`,
+            assume_role_policy: `jsonencode({
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
     }
+  ]
+})`,
+            tags: {
+              Name: `${node.data.name as string}-role`,
+              Environment: "terraform-generated",
+            },
+          },
+          dependencies: [],
+        })
+
+        // Add basic execution policy to IAM role
+        resources.push({
+          type: 'aws_iam_role_policy_attachment',
+          name: `${resourceName}_basic_execution`,
+          config: {
+            role: `aws_iam_role.${resourceName}_role.name`,
+            policy_arn: "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+          dependencies: [`aws_iam_role.${resourceName}_role`],
+        })
+
+        // Create default Lambda function ZIP file if using inline code
+        const useInlineCode = !node.data.config?.s3_bucket && !node.data.config?.s3_key
+        if (useInlineCode) {
+          // Create a simple archive resource for the Lambda function
+          resources.push({
+            type: 'archive_file',
+            name: `${resourceName}_lambda_zip`,
+            config: {
+              type: "zip",
+              output_path: `lambda-${resourceName}.zip`,
+              source: {
+                content: `exports.handler = async (event) => {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
+    },
+    body: JSON.stringify({
+      message: 'Hello from Lambda!',
+      timestamp: new Date().toISOString(),
+      requestId: event.requestContext?.requestId || 'local',
+      input: event
+    })
+  };
+};`,
+                filename: "index.js"
+              }
+            },
+            dependencies: [],
+          })
+
+          // Ensure the Lambda function depends on the archive
+          const lambdaResource = resources.find(r => r.type === 'aws_lambda_function' && r.name === resourceName)
+          if (lambdaResource) {
+            lambdaResource.dependencies = lambdaResource.dependencies || []
+            lambdaResource.dependencies.push(`archive_file.${resourceName}_lambda_zip`)
+          }
+        }
+      }
+    })
     
     return resources
   }
 
-  private async generateResourceConfig(node: Node): Promise<Record<string, any>> {
+  private generateResourceConfig(node: Node): Record<string, any> {
     const baseConfig = { ...(node.data.config as Record<string, any>) }
     const serviceId = node.data.id as string
 
-    // Load service configuration from JSON files
-    const serviceConfig = await ConfigLoader.loadServiceConfig(this.provider, serviceId)
-    
-    if (serviceConfig) {
-      // Merge user config with default config from JSON
-      const mergedConfig = { ...serviceConfig.defaultConfig, ...baseConfig }
-      
-      // Apply provider-specific configurations
-      switch (this.provider) {
-        case "aws":
-          return this.generateAWSConfig(serviceId, mergedConfig, node, serviceConfig)
-        case "gcp":
-          return this.generateGCPConfig(serviceId, mergedConfig, node, serviceConfig)
-        case "azure":
-          return this.generateAzureConfig(serviceId, mergedConfig, node, serviceConfig)
-        default:
-          return mergedConfig
-      }
-    }
-
-    // Fallback to old behavior if config loading fails
+    // Apply provider-specific configurations
     switch (this.provider) {
       case "aws":
         return this.generateAWSConfig(serviceId, baseConfig, node)
@@ -123,29 +175,21 @@ export class TerraformGenerator {
     }
   }
 
-  private generateAWSConfig(serviceId: string, config: Record<string, any>, node: Node, serviceConfig?: ServiceConfig): Record<string, any> {
+  private generateAWSConfig(serviceId: string, config: Record<string, any>, node: Node): Record<string, any> {
     const resourceConfig: Record<string, any> = { ...config }
 
-    // Add common fields
-    resourceConfig.tags = {
-      Name: config.name || node.data.name,
-      Environment: "terraform-generated",
-    }
-
-    // Add provider-specific fields based on service type
     switch (serviceId) {
       case "ec2":
-        // Use values from config (which includes defaults from JSON)
         return {
-          ami: config.ami,
-          instance_type: config.instance_type,
+          ami: config.ami || "ami-0abcdef1234567890",
+          instance_type: config.instance_type || "t3.micro",
           key_name: config.key_name || null,
-          vpc_security_group_ids: config.vpc_security_group_ids && config.vpc_security_group_ids.length > 0 
-            ? config.vpc_security_group_ids 
-            : [NetworkInfrastructureGenerator.getSecurityGroupReference()],
-          subnet_id: config.subnet_id || NetworkInfrastructureGenerator.getSubnetReference(serviceId),
-          associate_public_ip_address: config.associate_public_ip_address,
-          tags: resourceConfig.tags,
+          vpc_security_group_ids: this.getSecurityGroupReferences(node.id),
+          subnet_id: this.getSubnetReference(node.id),
+          tags: {
+            Name: config.name || `${node.data.name}-instance`,
+            Environment: "terraform-generated",
+          },
         }
 
       case "s3":
@@ -154,53 +198,76 @@ export class TerraformGenerator {
           versioning: {
             enabled: config.versioning === "Enabled",
           },
-          tags: resourceConfig.tags,
+          tags: {
+            Name: config.name || node.data.name,
+            Environment: "terraform-generated",
+          },
         }
 
       case "rds":
         return {
           identifier: config.db_name || `${this.sanitizeName(node.data.name as string)}-db`,
-          engine: config.engine,
-          engine_version: this.getEngineVersion(config.engine),
-          instance_class: config.instance_class,
+          engine: config.engine || "mysql",
+          engine_version: this.getEngineVersion(config.engine || "mysql"),
+          instance_class: config.instance_class || "db.t3.micro",
           allocated_storage: Number.parseInt(config.allocated_storage) || 20,
           db_name: config.db_name || "mydb",
           username: "admin",
           password: "var.db_password",
-          vpc_security_group_ids: [NetworkInfrastructureGenerator.getSecurityGroupReference()],
+          vpc_security_group_ids: this.getSecurityGroupReferences(node.id),
           db_subnet_group_name: this.getDBSubnetGroupReference(node.id),
           skip_final_snapshot: true,
-          tags: resourceConfig.tags,
+          tags: {
+            Name: config.name || node.data.name,
+            Environment: "terraform-generated",
+          },
         }
 
       case "lambda":
+        const resourceName = this.sanitizeName((node.data.name as string) || (node.data.id as string))
+        const useInlineCode = !config.s3_bucket && !config.s3_key
+
         return {
-          function_name: config.function_name || `${this.sanitizeName(node.data.name as string)}-function`,
-          runtime: config.runtime,
+          function_name: config.function_name || `${resourceName}-function`,
+          runtime: config.runtime || "nodejs18.x",
           handler: "index.handler",
-          filename: "lambda_function.zip",
+          ...(useInlineCode ? {
+            filename: `lambda-${resourceName}.zip`,
+          } : {
+            s3_bucket: config.s3_bucket || `var.lambda_s3_bucket`,
+            s3_key: config.s3_key || `var.lambda_s3_key`,
+          }),
           memory_size: Number.parseInt(config.memory_size) || 128,
           timeout: Number.parseInt(config.timeout) || 30,
-          role: "aws_iam_role.lambda_role.arn",
-          tags: resourceConfig.tags,
+          role: `aws_iam_role.${resourceName}_role.arn`,
+          tags: {
+            Name: config.name || node.data.name,
+            Environment: "terraform-generated",
+          },
         }
 
       case "vpc":
         return {
-          cidr_block: config.cidr_block,
+          cidr_block: config.cidr_block || "10.0.0.0/16",
           enable_dns_hostnames: config.enable_dns_hostnames !== false,
           enable_dns_support: config.enable_dns_support !== false,
-          tags: resourceConfig.tags,
+          tags: {
+            Name: config.name || `${node.data.name}-vpc`,
+            Environment: "terraform-generated",
+          },
         }
 
       case "alb":
         return {
           name: config.name || `${this.sanitizeName(node.data.name as string)}-alb`,
-          load_balancer_type: config.load_balancer_type,
-          scheme: config.scheme,
-          subnets: [NetworkInfrastructureGenerator.getSubnetReference(serviceId)],
-          security_groups: [NetworkInfrastructureGenerator.getSecurityGroupReference()],
-          tags: resourceConfig.tags,
+          load_balancer_type: config.load_balancer_type || "application",
+          scheme: config.scheme || "internet-facing",
+          subnets: [this.getSubnetReference(node.id)],
+          security_groups: this.getSecurityGroupReferences(node.id),
+          tags: {
+            Name: config.name || node.data.name,
+            Environment: "terraform-generated",
+          },
         }
 
       default:
@@ -208,7 +275,7 @@ export class TerraformGenerator {
     }
   }
 
-  private generateGCPConfig(serviceId: string, config: Record<string, any>, node: Node, serviceConfig?: ServiceConfig): Record<string, any> {
+  private generateGCPConfig(serviceId: string, config: Record<string, any>, node: Node): Record<string, any> {
     switch (serviceId) {
       case "compute":
         return {
@@ -255,7 +322,7 @@ export class TerraformGenerator {
     }
   }
 
-  private generateAzureConfig(serviceId: string, config: Record<string, any>, node: Node, serviceConfig?: ServiceConfig): Record<string, any> {
+  private generateAzureConfig(serviceId: string, config: Record<string, any>, node: Node): Record<string, any> {
     switch (serviceId) {
       case "vm":
         return {
@@ -341,6 +408,21 @@ export class TerraformGenerator {
       }
     }
 
+    // Add Lambda S3 variables if there are Lambda nodes
+    const hasLambda = this.nodes.some(node => node.data.id === 'lambda')
+    if (this.provider === "aws" && hasLambda) {
+      variables.lambda_s3_bucket = {
+        description: "S3 bucket containing the Lambda function code",
+        type: "string",
+        default: "my-lambda-bucket",
+      }
+      variables.lambda_s3_key = {
+        description: "S3 key (path) to the Lambda function ZIP file",
+        type: "string",
+        default: "lambda-function.zip",
+      }
+    }
+
     return variables
   }
 
@@ -385,6 +467,25 @@ export class TerraformGenerator {
             value: `${resourceType}.${resourceName}.dns_name`,
           }
           break
+
+        case "lambda":
+          outputs[`${resourceName}_function_name`] = {
+            description: `Name of ${node.data.name as string} Lambda function`,
+            value: `${resourceType}.${resourceName}.function_name`,
+          }
+          outputs[`${resourceName}_arn`] = {
+            description: `ARN of ${node.data.name as string} Lambda function`,
+            value: `${resourceType}.${resourceName}.arn`,
+          }
+          outputs[`${resourceName}_s3_bucket`] = {
+            description: `S3 bucket containing ${node.data.name as string} Lambda code`,
+            value: `${resourceType}.${resourceName}.s3_bucket`,
+          }
+          outputs[`${resourceName}_s3_key`] = {
+            description: `S3 key for ${node.data.name as string} Lambda code`,
+            value: `${resourceType}.${resourceName}.s3_key`,
+          }
+          break
       }
     })
 
@@ -421,14 +522,23 @@ export class TerraformGenerator {
     return versions[engine] || "8.0"
   }
 
+  private getSecurityGroupReferences(nodeId: string): string[] {
+    // This would be enhanced to find actual security group connections
+    return ["aws_security_group.default.id"]
+  }
+
+  private getSubnetReference(nodeId: string): string {
+    // This would be enhanced to find actual subnet connections
+    return "aws_subnet.main.id"
+  }
 
   private getDBSubnetGroupReference(nodeId: string): string {
     // This would be enhanced to find actual DB subnet group connections
     return "aws_db_subnet_group.main.name"
   }
 
-  async generateTerraformCode(): Promise<string> {
-    const output = await this.generate()
+  generateTerraformCode(): string {
+    const output = this.generate()
     let terraformCode = ""
 
     // Provider configuration
@@ -468,30 +578,23 @@ export class TerraformGenerator {
       terraformCode += "}\n\n"
     })
 
-
-    return terraformCode
-  }
-
-  async generateOutputsFile(): Promise<string> {
-    const output = await this.generate()
-    let outputsCode = ""
-
+    // Outputs
     if (Object.keys(output.outputs).length > 0) {
-      outputsCode += "# Outputs\n"
+      terraformCode += "# Outputs\n"
       Object.entries(output.outputs).forEach(([name, config]) => {
-        outputsCode += `output "${name}" {\n`
+        terraformCode += `output "${name}" {\n`
         Object.entries(config as Record<string, any>).forEach(([key, value]) => {
           if (typeof value === "string") {
-            outputsCode += `  ${key} = "${value}"\n`
+            terraformCode += `  ${key} = "${value}"\n`
           } else {
-            outputsCode += `  ${key} = ${value}\n`
+            terraformCode += `  ${key} = ${value}\n`
           }
         })
-        outputsCode += "}\n\n"
+        terraformCode += "}\n\n"
       })
     }
 
-    return outputsCode
+    return terraformCode
   }
 
   generateProviderBlock(): string {
@@ -502,6 +605,10 @@ export class TerraformGenerator {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
     }
   }
 }
@@ -562,20 +669,36 @@ resource "azurerm_resource_group" "main" {
       }
 
       if (typeof value === "string") {
-        if (
-          value.startsWith("var.") ||
-          value.startsWith("aws_") ||
-          value.startsWith("google_") ||
-          value.startsWith("azurerm_")
-        ) {
-          result += `${spaces}${key} = ${value}\n`
+        if (value.includes('\n')) {
+          // Use heredoc for multi-line strings
+          result += `${spaces}${key} = <<EOT\n${value}\nEOT\n`
         } else {
-          result += `${spaces}${key} = "${value}"\n`
+          // Escape inner double quotes for single-line
+          let formattedValue = value.replace(/"/g, '\\"')
+          if (value.startsWith("var.") ||
+              value.startsWith("aws_") ||
+              value.startsWith("google_") ||
+              value.startsWith("azurerm_")) {
+            result += `${spaces}${key} = ${formattedValue}\n`
+          } else {
+            result += `${spaces}${key} = "${formattedValue}"\n`
+          }
         }
       } else if (typeof value === "number" || typeof value === "boolean") {
         result += `${spaces}${key} = ${value}\n`
       } else if (Array.isArray(value)) {
-        result += `${spaces}${key} = [${value.map((v) => (typeof v === "string" ? `"${v}"` : v)).join(", ")}]\n`
+        result += `${spaces}${key} = [\n`
+        value.forEach((v, i) => {
+          if (typeof v === 'object' && v !== null) {
+            result += `${spaces}  {\n`
+            result += this.formatResourceConfig(v, indent + 2)
+            result += `${spaces}  }${i < value.length - 1 ? ',' : ''}\n`
+          } else {
+            const formatted = typeof v === "string" ? `"${v}"` : v
+            result += `${spaces}  ${formatted}${i < value.length - 1 ? ',' : ''}\n`
+          }
+        })
+        result += `${spaces}]\n`
       } else if (typeof value === "object") {
         // Special handling for different types of objects
         if (key === "tags" || parentKey === "tags") {


### PR DESCRIPTION
- Updated Terraform API routes to accept AWS credentials for operations (init, plan, apply, destroy, output, validate).
- Enhanced error handling for invalid AWS credentials.
- Modified the Terraform generator to include IAM roles and policies for Lambda functions.
- Updated .gitignore to include Terraform-related files and directories.